### PR TITLE
Bump convex and add the batch-worker dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@convex-dev/rate-limiter",
       "version": "0.3.2",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@convex-dev/batch-worker": "0.3.4"
+      },
       "devDependencies": {
         "@convex-dev/eslint-plugin": "^2.0.0",
         "@edge-runtime/vm": "5.0.0",
@@ -22,8 +25,8 @@
         "@vitejs/plugin-react": "5.1.4",
         "autoprefixer": "10.4.24",
         "chokidar-cli": "3.0.0",
-        "convex": "1.35.1",
-        "convex-test": "0.0.41",
+        "convex": "1.45.0",
+        "convex-test": "0.0.56",
         "dayjs": "1.11.19",
         "eslint": "9.39.2",
         "eslint-plugin-react-hooks": "7.0.1",
@@ -41,7 +44,7 @@
         "vitest": "4.1.0"
       },
       "peerDependencies": {
-        "convex": "^1.24.8",
+        "convex": "^1.43.0",
         "react": "^18.2.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -439,6 +442,18 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@convex-dev/batch-worker": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@convex-dev/batch-worker/-/batch-worker-0.3.4.tgz",
+      "integrity": "sha512-CKeOrPFsPoIKozMNP/qKExSwE6vd63QDKbZIbchK+P3S7fyGuFjRLbTg6+QmC/mzOjn6I5N8zo+k/SdXqeaA2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "convex-helpers": "^0.1.119"
+      },
+      "peerDependencies": {
+        "convex": "^1.43.0"
       }
     },
     "node_modules/@convex-dev/eslint-plugin": {
@@ -1175,7 +1190,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1936,7 +1950,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -3303,27 +3317,26 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.35.1.tgz",
-      "integrity": "sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ==",
-      "dev": true,
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.45.0.tgz",
+      "integrity": "sha512-AV3B56Ptu/14d76g3urBJ50dwpiZa6uJaLT84OWox5aCwZIJiuAamdjv3lLHDzs8vv5kC31anEZohhUe3qJ2bA==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
-        "ws": "8.18.0"
+        "ws": "8.21.0"
       },
       "bin": {
         "convex": "bin/main.js"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=20.0.0",
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
         "@auth0/auth0-react": "^2.0.1",
         "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
-        "@clerk/react": "^6.0.0",
+        "@clerk/react": "^6.4.3",
         "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -3341,14 +3354,48 @@
         }
       }
     },
+    "node_modules/convex-helpers": {
+      "version": "0.1.123",
+      "resolved": "https://registry.npmjs.org/convex-helpers/-/convex-helpers-0.1.123.tgz",
+      "integrity": "sha512-E9W4tscZy6ZtNnwPDdL5UhMc7Rj9aUYlzjdYiKsfVIAwdarABWqvPB8+St3Q6IwS83r+QIGSO1lTidTamDdyPQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "convex-helpers": "bin.cjs"
+      },
+      "peerDependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "convex": "^1.43.0",
+        "hono": "^4.0.5",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "typescript": "^5.5 || ^6.0.0 || ^7.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@standard-schema/spec": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/convex-test": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.41.tgz",
-      "integrity": "sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ==",
+      "version": "0.0.56",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.56.tgz",
+      "integrity": "sha512-dLYXlQjKFoGqvjAmPzyLgb2HsYI7iLo1iuNTU2DZmSrMRLWosYk94erjSU67GG5ovfP6+MjX8RJO+ebhmL6QYA==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "convex": "^1.16.4"
+        "convex": "^1.43.0"
       }
     },
     "node_modules/convex/node_modules/@esbuild/aix-ppc64": {
@@ -3358,7 +3405,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3375,7 +3421,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3392,7 +3437,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3409,7 +3453,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3426,7 +3469,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3443,7 +3485,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3460,7 +3501,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3477,7 +3517,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3494,7 +3533,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3511,7 +3549,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3528,7 +3565,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3545,7 +3581,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3562,7 +3597,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3579,7 +3613,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3596,7 +3629,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3613,7 +3645,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3630,7 +3661,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3647,7 +3677,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3664,7 +3693,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3681,7 +3709,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3698,7 +3725,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3715,7 +3741,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3732,7 +3757,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3749,7 +3773,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3766,7 +3789,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3780,7 +3802,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
       "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5413,7 +5434,6 @@
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -5469,7 +5489,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5913,7 +5933,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6305,10 +6325,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6525,7 +6544,7 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -64,8 +64,11 @@
       "default": "./dist/component/convex.config.js"
     }
   },
+  "dependencies": {
+    "@convex-dev/batch-worker": "0.3.4"
+  },
   "peerDependencies": {
-    "convex": "^1.24.8",
+    "convex": "^1.43.0",
     "react": "^18.2.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
@@ -87,8 +90,8 @@
     "@vitejs/plugin-react": "5.1.4",
     "autoprefixer": "10.4.24",
     "chokidar-cli": "3.0.0",
-    "convex": "1.35.1",
-    "convex-test": "0.0.41",
+    "convex": "1.45.0",
+    "convex-test": "0.0.56",
     "dayjs": "1.11.19",
     "eslint": "9.39.2",
     "eslint-plugin-react-hooks": "7.0.1",


### PR DESCRIPTION
convex >= 1.43 is needed for v.commitTs() and useStaleSnapshot. The
example/convex/_generated diff is codegen output from the newer convex.
Also formats the two files main's prettier check was flagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Stack** (review bottom-up; each PR is based on the one above it)
1. #57 Bump convex and add the batch-worker dependency
2. #58 Install batch-worker in the component and add the pending-updates queue
3. #59 Add the lazy rate-limit worker
4. #60 Add a per-limit `lazy` option to RateLimiter
5. #61 Make `lazy` and `shards` mutually exclusive in the types
6. #54 Document lazy rate limits
