### PR TITLE
Add a per-limit `applyUpdates` option to RateLimiter

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -1,6 +1,19 @@
-import { expect, test } from "vitest";
-import { ConvexError } from "convex/values";
-import { isRateLimitError, type RateLimitError } from "./index.js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ConvexError, v } from "convex/values";
+import {
+  anyApi,
+  type ApiFromModules,
+  mutationGeneric,
+  queryGeneric,
+} from "convex/server";
+import {
+  HOUR,
+  isRateLimitError,
+  RateLimiter,
+  type RateLimitError,
+} from "./index.js";
+import { components, initConvexTest } from "./setup.test.js";
+
 test("isRateLimitError", () => {
   expect(
     isRateLimitError(
@@ -12,4 +25,232 @@ test("isRateLimitError", () => {
     ),
   ).toBe(true);
   expect(isRateLimitError(new ConvexError({ kind: "foo" }))).toBe(false);
+});
+
+const rateLimiter = new RateLimiter(components.rateLimiter, {
+  strict: { kind: "token bucket", rate: 10, period: HOUR, capacity: 3 },
+  async: {
+    kind: "token bucket",
+    rate: 10,
+    period: HOUR,
+    capacity: 3,
+    applyUpdates: "asynchronously",
+  },
+});
+
+const LIMITS = ["strict", "async"] as const;
+type LimitName = (typeof LIMITS)[number];
+const vLimit = v.union(...LIMITS.map((name) => v.literal(name)));
+
+export const consume = mutationGeneric({
+  args: {
+    limit: vLimit,
+    key: v.optional(v.string()),
+    count: v.optional(v.number()),
+    throws: v.optional(v.boolean()),
+    reserve: v.optional(v.boolean()),
+  },
+  handler: async (ctx, { limit, key, count, throws, reserve }) =>
+    rateLimiter.limit(ctx, limit as LimitName, { key, count, throws, reserve }),
+});
+
+export const check = queryGeneric({
+  args: { limit: vLimit, key: v.optional(v.string()) },
+  handler: async (ctx, { limit, key }) =>
+    rateLimiter.check(ctx, limit as LimitName, { key }),
+});
+
+export const value = queryGeneric({
+  args: { limit: vLimit, key: v.optional(v.string()) },
+  handler: async (ctx, { limit, key }) =>
+    rateLimiter.getValue(ctx, limit as LimitName, { key }),
+});
+
+export const reset = mutationGeneric({
+  args: { limit: vLimit, key: v.optional(v.string()) },
+  handler: async (ctx, { limit, key }) =>
+    rateLimiter.reset(ctx, limit as LimitName, { key }),
+});
+
+export const inlineAsync = mutationGeneric({
+  args: { count: v.number() },
+  handler: async (ctx, { count }) =>
+    rateLimiter.limit(ctx, "inline", {
+      count,
+      config: {
+        kind: "token bucket",
+        rate: 100,
+        period: HOUR,
+        applyUpdates: "asynchronously",
+      },
+    }),
+});
+
+export const { getRateLimit } = rateLimiter.hookAPI("async", { key: "u" });
+
+export const resetInlineAsync = mutationGeneric({
+  args: {},
+  handler: async (ctx) =>
+    rateLimiter.reset(ctx, "inline", {
+      config: {
+        kind: "token bucket",
+        rate: 100,
+        period: HOUR,
+        applyUpdates: "asynchronously",
+      },
+    }),
+});
+
+const testApi = (
+  anyApi as unknown as ApiFromModules<{
+    "index.test": {
+      consume: typeof consume;
+      check: typeof check;
+      value: typeof value;
+      reset: typeof reset;
+      getRateLimit: typeof getRateLimit;
+      inlineAsync: typeof inlineAsync;
+      resetInlineAsync: typeof resetInlineAsync;
+    };
+  }>
+)["index.test"];
+
+type TestConvex = ReturnType<typeof initConvexTest>;
+
+async function drain(t: TestConvex) {
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+}
+
+async function valueOf(t: TestConvex, limit: LimitName, key?: string) {
+  return (await t.query(testApi.value, { limit, key })).value;
+}
+
+describe("asynchronous", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("limit and reset queue their writes instead of applying them", async () => {
+    const t = initConvexTest();
+    for (let i = 0; i < 3; i++) {
+      expect(await t.mutation(testApi.consume, { limit: "async" })).toEqual({
+        ok: true,
+        retryAfter: undefined,
+      });
+    }
+    // All three succeeded, but nothing has been written yet.
+    expect(await valueOf(t, "async")).toBe(3);
+
+    await drain(t);
+    expect(await valueOf(t, "async")).toBe(0);
+    const blocked = await t.query(testApi.check, { limit: "async" });
+    expect(blocked.ok).toBe(false);
+    expect(blocked.retryAfter).toBeGreaterThan(0);
+
+    // `reset` on a named asynchronous limit is queued the same way.
+    await t.mutation(testApi.reset, { limit: "async" });
+    await drain(t);
+    expect((await t.query(testApi.check, { limit: "async" })).ok).toBe(true);
+  });
+
+  test("rejected asynchronous calls consume nothing", async () => {
+    const t = initConvexTest();
+    // Every call reads a stale value of 3, so all four are allowed through and
+    // the limit overshoots into the negative once the worker catches up.
+    for (let i = 0; i < 4; i++) {
+      await t.mutation(testApi.consume, { limit: "async" });
+    }
+    await drain(t);
+    const before = await valueOf(t, "async");
+    expect(before).toBeLessThan(0);
+
+    expect((await t.mutation(testApi.consume, { limit: "async" })).ok).toBe(
+      false,
+    );
+    await drain(t);
+    expect(await valueOf(t, "async")).toBe(before);
+  });
+
+  test("reserve lets an asynchronous limit go into debt", async () => {
+    const t = initConvexTest();
+    // 5 against a capacity of 3: only allowed because `reserve` is set.
+    const reserved = await t.mutation(testApi.consume, {
+      limit: "async",
+      count: 5,
+      reserve: true,
+    });
+    expect(reserved.ok).toBe(true);
+    expect(reserved.retryAfter).toBeGreaterThan(0);
+
+    await drain(t);
+    expect(await valueOf(t, "async")).toBe(-2);
+  });
+
+  test("throws a RateLimitError when `throws` is true", async () => {
+    const t = initConvexTest();
+    for (let i = 0; i < 3; i++) {
+      await t.mutation(testApi.consume, { limit: "async", throws: true });
+    }
+    await drain(t);
+    const error = await t
+      .mutation(testApi.consume, { limit: "async", throws: true })
+      .catch((e) => e);
+    expect(isRateLimitError(error)).toBe(true);
+  });
+
+  test("limit and reset honor `applyUpdates` from an inline config", async () => {
+    const t = initConvexTest();
+    expect((await t.mutation(testApi.inlineAsync, { count: 60 })).ok).toBe(
+      true,
+    );
+    await drain(t);
+    expect((await t.mutation(testApi.inlineAsync, { count: 60 })).ok).toBe(
+      false,
+    );
+    await t.mutation(testApi.resetInlineAsync, {});
+    await drain(t);
+    expect((await t.mutation(testApi.inlineAsync, { count: 60 })).ok).toBe(
+      true,
+    );
+  });
+
+  test("hookAPI resolves its configured key against an asynchronous limit", async () => {
+    const t = initConvexTest();
+    expect((await t.query(testApi.getRateLimit, {})).value).toBe(3);
+
+    for (let i = 0; i < 2; i++) {
+      await t.mutation(testApi.consume, { limit: "async", key: "u" });
+    }
+    await drain(t);
+
+    const data = await t.query(testApi.getRateLimit, {});
+    expect(data.value).toBe(1);
+    expect(data.shard).toBe(0);
+    expect(data.config.shards).toBe(1);
+  });
+});
+
+describe("transactional", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("limit consumes the rate limit", async () => {
+    const t = initConvexTest();
+    for (let i = 0; i < 3; i++) {
+      expect((await t.mutation(testApi.consume, { limit: "strict" })).ok).toBe(
+        true,
+      );
+    }
+    expect(await valueOf(t, "strict")).toBe(0);
+    expect((await t.mutation(testApi.consume, { limit: "strict" })).ok).toBe(
+      false,
+    );
+  });
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,8 @@
 import {
   type Expand,
+  type FunctionArgs,
+  type FunctionReference,
+  type FunctionReturnType,
   type GenericActionCtx,
   type GenericDataModel,
   type GenericMutationCtx,
@@ -102,11 +105,11 @@ export class RateLimiter<
       ? [WithKnownNameOrInlinedConfig<Limits, Name, RateLimitArgs>?]
       : [WithKnownNameOrInlinedConfig<Limits, Name, RateLimitArgs>]
   ): Promise<RateLimitReturns> {
-    return ctx.runQuery(this.component.lib.checkRateLimit, {
-      ...options[0],
-      name,
-      config: this.getConfig(options[0], name),
-    });
+    const config = this.getConfig(options[0], name);
+    const args = { ...options[0], name, config };
+    return config.applyUpdates === "asynchronously"
+      ? runStaleQuery(ctx, this.component.lib.checkRateLimit, args)
+      : ctx.runQuery(this.component.lib.checkRateLimit, args);
   }
 
   /**
@@ -137,12 +140,37 @@ export class RateLimiter<
       ? [WithKnownNameOrInlinedConfig<Limits, Name, RateLimitArgs>?]
       : [WithKnownNameOrInlinedConfig<Limits, Name, RateLimitArgs>]
   ): Promise<RateLimitReturns> {
-    return ctx.runMutation(this.component.lib.rateLimit, {
-      ...options[0],
-      name,
-      config: this.getConfig(options[0], name),
+    const config = this.getConfig(options[0], name);
+    if (config.applyUpdates !== "asynchronously") {
+      return ctx.runMutation(this.component.lib.rateLimit, {
+        ...options[0],
+        name,
+        config,
+      });
+    }
+    const args = { ...options[0], name, config };
+    const status = await runStaleQuery(
+      ctx,
+      this.component.lib.checkRateLimit,
+      args,
+    );
+    if (!status.ok) return status;
+    const { key, count } = args as RateLimitArgs;
+    await ctx.runMutation(this.component.lib.enqueueUpdates, {
+      updates: [
+        {
+          kind: "consume",
+          name,
+          key,
+          count: count ?? 1,
+          config,
+          ts: Date.now(),
+        },
+      ],
     });
+    return status;
   }
+
   /**
    * Reset a rate limit. This will remove the rate limit from the database.
    * The next request will start fresh.
@@ -150,18 +178,25 @@ export class RateLimiter<
    * the new window will be a random time.
    * @param ctx The ctx object from a mutation, including runMutation.
    * @param name The name of the rate limit to reset, including all shards.
-   * @param key If a key is provided, it will reset the rate limit for that key.
-   * If not, it will reset the rate limit for the shared value.
+   * @param options The rate limit arguments. If a key is provided, it will
+   * reset the rate limit for that key. If not, it will reset the rate limit
+   * for the shared value. `config` is required if the rate limit was not
+   * defined in {@link RateLimiter}. See {@link RateLimitArgs}.
    */
   async reset<Name extends string = keyof Limits & string>(
     { runMutation }: MutationCtx | ActionCtx,
     name: Name,
-    args?: { key?: string },
+    args?: { key?: string; config?: RateLimitConfig },
   ): Promise<void> {
-    await runMutation(this.component.lib.resetRateLimit, {
-      ...(args ?? null),
-      name,
-    });
+    const config = args?.config ?? this.limits?.[name];
+    const resetArgs = { key: args?.key, name };
+    if (config?.applyUpdates === "asynchronously") {
+      await runMutation(this.component.lib.enqueueUpdates, {
+        updates: [{ kind: "reset", ...resetArgs }],
+      });
+    } else {
+      await runMutation(this.component.lib.resetRateLimit, resetArgs);
+    }
   }
 
   /**
@@ -183,28 +218,22 @@ export class RateLimiter<
           WithKnownNameOrInlinedConfig<
             Limits,
             Name,
-            {
-              key?: string;
-              sampleShards?: number;
-            }
+            { key?: string; sampleShards?: number }
           >?,
         ]
       : [
           WithKnownNameOrInlinedConfig<
             Limits,
             Name,
-            {
-              key?: string;
-              sampleShards?: number;
-            }
+            { key?: string; sampleShards?: number }
           >,
         ]
   ): Promise<GetValueReturns> {
-    return ctx.runQuery(this.component.lib.getValue, {
-      ...options[0],
-      name,
-      config: this.getConfig(options[0], name),
-    });
+    const config = this.getConfig(options[0], name);
+    const args = { ...options[0], name, config };
+    return config.applyUpdates === "asynchronously"
+      ? runStaleQuery(ctx, this.component.lib.getValue, args)
+      : ctx.runQuery(this.component.lib.getValue, args);
   }
 
   /**
@@ -283,22 +312,49 @@ export class RateLimiter<
           `You must provide a config inline or define it in the constructor.`,
       );
     }
+    if (
+      config.applyUpdates === "asynchronously" &&
+      config.shards !== undefined
+    ) {
+      throw new Error(
+        `Rate limit ${name} applies updates asynchronously and can't be sharded.`,
+      );
+    }
     return config;
   }
 }
 
 export default RateLimiter;
 
+/**
+ * Run the given query. If inside a mutation, uses a stale snapshot.
+ */
+async function runStaleQuery<
+  Query extends FunctionReference<"query", "internal">,
+>(
+  ctx: QueryCtx | MutationCtx | ActionCtx,
+  query: Query,
+  args: FunctionArgs<Query>,
+): Promise<FunctionReturnType<Query>> {
+  const { type } = await ctx.meta.getFunctionMetadata();
+  return type === "mutation"
+    ? (ctx as MutationCtx).runQuery(query, args, { useStaleSnapshot: true })
+    : ctx.runQuery(query, args);
+}
+
 // Type utilities
 
-export type QueryCtx = Pick<GenericQueryCtx<GenericDataModel>, "runQuery">;
+export type QueryCtx = Pick<
+  GenericQueryCtx<GenericDataModel>,
+  "runQuery" | "meta"
+>;
 export type MutationCtx = Pick<
   GenericMutationCtx<GenericDataModel>,
-  "runQuery" | "runMutation"
+  "runQuery" | "runMutation" | "meta"
 >;
 export type ActionCtx = Pick<
   GenericActionCtx<GenericDataModel>,
-  "runQuery" | "runMutation" | "runAction"
+  "runQuery" | "runMutation" | "runAction" | "meta"
 >;
 type WithKnownNameOrInlinedConfig<
   Limits extends Record<string, RateLimitConfig>,

--- a/src/client/setup.test.ts
+++ b/src/client/setup.test.ts
@@ -1,0 +1,30 @@
+/// <reference types="vite/client" />
+import { test } from "vitest";
+import { convexTest } from "convex-test";
+export const modules = {
+  ...import.meta.glob("./**/*.*s"),
+  "./_generated/api.ts": async () => ({}),
+};
+
+import {
+  componentsGeneric,
+  defineSchema,
+  type GenericSchema,
+  type SchemaDefinition,
+} from "convex/server";
+import type { ComponentApi } from "../component/_generated/component.js";
+import { register } from "../test.js";
+
+export function initConvexTest<
+  Schema extends SchemaDefinition<GenericSchema, boolean>,
+>(schema?: Schema) {
+  const t = convexTest(schema ?? (defineSchema({}) as Schema), modules);
+  register(t);
+  return t;
+}
+
+export const components = componentsGeneric() as unknown as {
+  rateLimiter: ComponentApi;
+};
+
+test("setup", () => {});

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -30,6 +30,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         {
           config:
             | {
+                applyUpdates?: "transactionally" | "asynchronously";
                 capacity?: number;
                 kind: "token bucket";
                 maxReserved?: number;
@@ -39,6 +40,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                 start?: null;
               }
             | {
+                applyUpdates?: "transactionally" | "asynchronously";
                 capacity?: number;
                 kind: "fixed window";
                 maxReserved?: number;
@@ -71,6 +73,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             | {
                 config:
                   | {
+                      applyUpdates?: "transactionally" | "asynchronously";
                       capacity?: number;
                       kind: "token bucket";
                       maxReserved?: number;
@@ -80,6 +83,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                       start?: null;
                     }
                   | {
+                      applyUpdates?: "transactionally" | "asynchronously";
                       capacity?: number;
                       kind: "fixed window";
                       maxReserved?: number;
@@ -113,6 +117,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         {
           config:
             | {
+                applyUpdates?: "transactionally" | "asynchronously";
                 capacity?: number;
                 kind: "token bucket";
                 maxReserved?: number;
@@ -122,6 +127,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                 start?: null;
               }
             | {
+                applyUpdates?: "transactionally" | "asynchronously";
                 capacity?: number;
                 kind: "fixed window";
                 maxReserved?: number;
@@ -137,6 +143,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         {
           config:
             | {
+                applyUpdates?: "transactionally" | "asynchronously";
                 capacity?: number;
                 kind: "token bucket";
                 maxReserved?: number;
@@ -146,6 +153,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                 start?: null;
               }
             | {
+                applyUpdates?: "transactionally" | "asynchronously";
                 capacity?: number;
                 kind: "fixed window";
                 maxReserved?: number;
@@ -166,6 +174,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         {
           config:
             | {
+                applyUpdates?: "transactionally" | "asynchronously";
                 capacity?: number;
                 kind: "token bucket";
                 maxReserved?: number;
@@ -175,6 +184,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                 start?: null;
               }
             | {
+                applyUpdates?: "transactionally" | "asynchronously";
                 capacity?: number;
                 kind: "fixed window";
                 maxReserved?: number;

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -400,3 +400,51 @@ describe.each(["token bucket", "fixed window"] as const)(
     });
   },
 );
+
+describe("asynchronous configs", () => {
+  const config = {
+    kind: "token bucket",
+    rate: 1,
+    period: Hour,
+    applyUpdates: "asynchronously",
+  } as const;
+
+  test("can't be applied by rateLimit", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(api.lib.rateLimit, { name: "async", config }),
+    ).rejects.toThrow(
+      'Rate limit config for async has `applyUpdates: "asynchronously"`',
+    );
+  });
+
+  test("can't be queued when updates are applied transactionally", async () => {
+    const t = convexTest(schema, modules);
+    const update = {
+      kind: "consume" as const,
+      name: "eager",
+      count: 1,
+      config: { ...config, applyUpdates: "transactionally" as const },
+      ts: Date.now(),
+    };
+    await expect(
+      t.mutation(api.lib.enqueueUpdates, { updates: [update] }),
+    ).rejects.toThrow(
+      'Rate limit config for eager has `applyUpdates: "transactionally"`',
+    );
+  });
+
+  test("are readable, since the async path checks through the same query", async () => {
+    const t = convexTest(schema, modules);
+    expect(
+      await t.query(api.lib.checkRateLimit, { name: "async", config }),
+    ).toEqual({ ok: true, retryAfter: undefined });
+    const { value, config: applied } = await t.query(api.lib.getValue, {
+      name: "async",
+      config,
+    });
+    expect(value).toBe(1);
+    // Collapsed onto the singleton shard the worker writes.
+    expect(applied.shards).toBe(1);
+  });
+});

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -21,6 +21,11 @@ export const rateLimit = mutation({
   args: rateLimitArgs,
   returns: rateLimitReturns,
   handler: async (ctx, args) => {
+    if (args.config.applyUpdates === "asynchronously") {
+      throw new Error(
+        `Rate limit config for ${args.name} has \`applyUpdates: "asynchronously"\`. Limit consumption must be enqueued.`,
+      );
+    }
     const { status, updates } = await checkRateLimitOrThrow(ctx.db, args);
     for (const { value, ts, existing, shard } of updates) {
       if (existing) {
@@ -107,6 +112,16 @@ export const enqueueUpdates = mutation({
   args: { updates: v.array(vPendingUpdate) },
   returns: v.null(),
   handler: async (ctx, { updates }) => {
+    for (const update of updates) {
+      if (
+        update.kind === "consume" &&
+        update.config.applyUpdates === "transactionally"
+      ) {
+        throw new Error(
+          `Rate limit config for ${update.name} has \`applyUpdates: "transactionally"\` and can't be enqueued.`,
+        );
+      }
+    }
     await Promise.all(
       updates.map((update) =>
         ctx.db.insert("pendingUpdates", {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -16,6 +16,9 @@ export const tokenBucketValidator = v.object({
   capacity: v.optional(v.number()),
   maxReserved: v.optional(v.number()),
   shards: v.optional(v.number()),
+  applyUpdates: v.optional(
+    v.union(v.literal("transactionally"), v.literal("asynchronously")),
+  ),
   start: v.optional(v.null()),
 });
 
@@ -34,6 +37,9 @@ export const fixedWindowValidator = v.object({
   capacity: v.optional(v.number()),
   maxReserved: v.optional(v.number()),
   shards: v.optional(v.number()),
+  applyUpdates: v.optional(
+    v.union(v.literal("transactionally"), v.literal("asynchronously")),
+  ),
   start: v.optional(v.number()),
 });
 
@@ -130,7 +136,10 @@ export const getValueReturns = v.object({
 
 export type GetValueReturns = Infer<typeof getValueReturns>;
 
-/** Lazy rate limits are never sharded: every update lands on this shard. */
+/**
+ * Rate limits that apply updates asynchronously are never sharded: every
+ * update lands on this shard.
+ */
 export const SINGLETON_SHARD = 0;
 
 export const vPendingUpdate = v.union(


### PR DESCRIPTION
Add the ability to set a limit's `applyUpdates` to `"asynchronously"` in RateLimiter

---
**Stack**
1. #57
2. #58
3. #59
4. #60
5. #61
6. #54

