### PR TITLE
Release 0.4.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.0
+## 0.4.0-alpha
 
 - Add a new async mode to the Rate Limiter component that improves throughput
   under highly concurrent workloads. Setting `applyUpdates: "asynchronously"` on

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/rate-limiter",
-  "version": "0.3.2",
+  "version": "0.4.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/rate-limiter",
-      "version": "0.3.2",
+      "version": "0.4.0-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@convex-dev/batch-worker": "0.3.4"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/rate-limiter/issues"
   },
-  "version": "0.3.2",
+  "version": "0.4.0-alpha.0",
   "license": "Apache-2.0",
   "keywords": [
     "convex",


### PR DESCRIPTION
Bump to `0.4.0-alpha.0` to cut an alpha of the async rate limiter off `main`.

Contains only the version bump (`package.json`, `package-lock.json`) and the
CHANGELOG heading for the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)